### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - dev
       - main
+permissions:
+  contents: read
 jobs:
   run-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/0xLaurens/sendfa.st/security/code-scanning/1](https://github.com/0xLaurens/sendfa.st/security/code-scanning/1)

To fix this, add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
The best minimal fix (without changing functionality) is to add at the workflow root:

- `permissions:`
  - `contents: read`

This covers the current job needs (checkout and test execution) and satisfies CodeQL’s recommendation.  
Make this change in `.github/workflows/development.yml`, immediately after the `on:` trigger block and before `jobs:`.

No imports, methods, or external definitions are needed; this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
